### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/ppgnn/security/code-scanning/1](https://github.com/microsoft/ppgnn/security/code-scanning/1)

Generally, to fix this issue you add a `permissions` block either at the top level of the workflow (applies to all jobs) or inside the job that CodeQL flagged. The block should grant only the scopes needed, typically `contents: read` for simple CI tasks that only read the code and do not modify GitHub resources.

For this specific workflow, the job only checks out the repository, installs Python/pylint, and runs analysis; it does not create or modify issues, pull requests, releases, or repository contents. The minimal safe fix is to add `permissions: contents: read`. Since there is a single job, we can place this at the workflow root so it applies to all jobs. Concretely, in `.github/workflows/pylint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on: [push]` line and the `jobs:` line. No imports or additional methods are needed; this is purely a YAML configuration change and does not alter the existing runtime behavior of the job, aside from reducing its token privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
